### PR TITLE
Change timer event to P5S

### DIFF
--- a/example/test.bpmn
+++ b/example/test.bpmn
@@ -22,7 +22,7 @@
       <bpmn:incoming>SequenceFlow_0813z63</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0dssivi</bpmn:outgoing>
       <bpmn:timerEventDefinition>
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PTS5</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0813z63" sourceRef="ExclusiveGateway_0wne7eb" targetRef="IntermediateCatchEvent_04zcf15" />


### PR DESCRIPTION
After running workflow.js, I get
```
 INVALID_ARGUMENT: Command rejected with code 'CREATE': Expected to deploy new resources, but encountered the following validation errors:
'test.bpmn': - Element: IntermediateCatchEvent_04zcf15 > timerEventDefinition
    - ERROR: Time duration is invalid
```
Zeebe version : 0.15.0-alpha1

Timer duration is PTS5 and should be PT5S. It's also mentionned here https://docs.zeebe.io/bpmn-workflows/timer-events.html Other than that, It works like a charm! Thanks for open-source this client!
