### PR TITLE
Feature/export zb worker class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./zb/ZBClient";
+export * from "./zb/ZBWorker";
 export {BpmnParser} from "./lib/BpmnParser";


### PR DESCRIPTION
Let's say, we have a class and I want to keep a ref like this `private _worker: ZBWorker;`, I can't specify `ZBWorker` because he is not exported.