### PR TITLE
Fix env order for loglevel

### DIFF
--- a/src/__mocks__/zbClientOptions.ts
+++ b/src/__mocks__/zbClientOptions.ts
@@ -1,0 +1,12 @@
+import { Loglevel } from '../lib/interfaces'
+
+export const clientOptions = {
+	_loglevel: 'NONE' as Loglevel,
+	// it's a setter!
+	set loglevel(value: Loglevel) {
+		this._loglevel = value
+	},
+	get loglevel(): Loglevel {
+		return this._loglevel
+	},
+}

--- a/src/__tests__/ZBClient.spec.ts
+++ b/src/__tests__/ZBClient.spec.ts
@@ -1,8 +1,10 @@
 import { ZBClient } from '..'
-
-process.env.ZB_NODE_LOG_LEVEL = process.env.ZB_NODE_LOG_LEVEL || 'NONE'
+import { clientOptions } from '../__mocks__/zbClientOptions'
 
 describe('ZBClient constructor', () => {
+	beforeEach(() => {
+		process.env.ZB_NODE_LOG_LEVEL = process.env.ZB_NODE_LOG_LEVEL || 'NONE'
+	})
 	it('creates a new ZBClient', () => {
 		const zbc = new ZBClient('localhost')
 		expect(zbc instanceof ZBClient).toBe(true)
@@ -17,5 +19,24 @@ describe('ZBClient constructor', () => {
 	})
 	it('throws an exception when not provided a brokerAddress in the constructor', () => {
 		expect(() => new (ZBClient as any)()()).toThrow()
+	})
+	it('takes client options passed in Ctor when ZB_NODE_LOG_LEVEL is not defined', () => {
+		process.env.ZB_NODE_LOG_LEVEL = ''
+		clientOptions.loglevel = 'DEBUG'
+		const spy = jest.spyOn(clientOptions, 'loglevel', 'get')
+		expect(new ZBClient('localhost', clientOptions)).toBeInstanceOf(
+			ZBClient
+		)
+		expect(spy).toHaveBeenCalled()
+		spy.mockRestore()
+	})
+	it('ZB_NODE_LOG_LEVEL precedes options passed in Ctor', () => {
+		clientOptions.loglevel = 'DEBUG'
+		const spy = jest.spyOn(clientOptions, 'loglevel', 'get')
+		expect(new ZBClient('localhost', clientOptions)).toBeInstanceOf(
+			ZBClient
+		)
+		expect(spy).toBeCalledTimes(0)
+		spy.mockRestore()
 	})
 })

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -31,8 +31,8 @@ export class ZBClient {
 		}
 		this.options = options || {}
 		this.options.loglevel =
-			options.loglevel ||
 			(process.env.ZB_NODE_LOG_LEVEL as ZB.Loglevel) ||
+			options.loglevel ||
 			'INFO'
 
 		if (brokerAddress.indexOf(':') === -1) {


### PR DESCRIPTION
ZB_NODE_LOG_LEVEL should precede options given in the ctor
Add 2 tests (with and without env variable)

closes #11