### PR TITLE
Load-balance and enable idempotent start messages

### DIFF
--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -203,6 +203,7 @@ export interface PublishStartMessageRequest<Variables = KeyedObject> {
 	timeToLive: number
 	/** Unique ID for this message */
 	messageId?: string
+	correlationKey?: string
 	variables: Variables
 }
 


### PR DESCRIPTION
Fixes #28.

* Adds a uuid as the correlationKey on start messages created by `publishStartMessage()`. This load-balances of workflow instances create via this method, across partitions.
* Passes through any user-supplied correlationKey to enable idempotent start messages.