### PR TITLE
Update to 2.2.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "2.2.0-beta.1",
+	"version": "2.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "2.2.0-beta.1",
+	"version": "2.2.0",
 	"description": "A Node.js client library for the Zeebe Microservices Orchestration Engine.",
 	"keywords": [
 		"zeebe",


### PR DESCRIPTION
- Tested latest PR's in house, no problems
- Added a npmrc so `npm version` appends a git tag that actually works