### PR TITLE
Add client-side retry, remove listWorkflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:11.10.1
-      - image: camunda/zeebe:0.17.0
+      - image: camunda/zeebe:0.18.0
     working_directory: ~/zeebe-client-node-js
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 2.4.0
+
+• Update for Zeebe 0.18.
+• Remove `ZBClient.listWorkflows` and `ZBClient.getWorkflow` - the broker no longer supports them.
+• Remove `{redeploy: boolean}` option from `ZBClient.deployWorkflow` method. This relies on `listWorkflows`.
+• Add `{retry: boolean}` to ZBClient constructor options. Defaults to true. Retries ZBClient gRPC command methods on failure. See [#40](https://github.com/creditsenseau/zeebe-client-node-js/issues/40).
+
 # Version 1.2.0
 
 • Integration tests in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Version 2.4.0
 
 • Update for Zeebe 0.18.
-• Remove `ZBClient.listWorkflows` and `ZBClient.getWorkflow` - the broker no longer supports them.
-• Remove `{redeploy: boolean}` option from `ZBClient.deployWorkflow` method. This relies on `listWorkflows`.
-• Add `{retry: boolean}` to ZBClient constructor options. Defaults to true. Retries ZBClient gRPC command methods on failure. See [#40](https://github.com/creditsenseau/zeebe-client-node-js/issues/40).
+• Remove `ZBClient.listWorkflows` and `ZBClient.getWorkflow` - the broker no longer provides a query API.
+• Remove `{redeploy: boolean}` option from `ZBClient.deployWorkflow` method. This relies on `listWorkflows`. This will be the default behaviour in a future release of Zeebe. See [zeebe/#1159](https://github.com/zeebe-io/zeebe/issues/1159).
+• Add client-side retry logic. Retries ZBClient gRPC command methods on failure due to [gRPC error code 14](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) (Transient Network Error). See [#40](https://github.com/creditsenseau/zeebe-client-node-js/issues/40).
 
 # Version 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If no workers have been started, this can be fatal to the process if it is not h
 
 To mitigate against this, the Node client implements some client-side gRPC operation retry logic by default. This can be configured, including disabled, via configuration in the client constructor.
 
--   Operations retry, but only if the error message starts with '14' - indicating a network error. This can be caused by passing in an unresolvable gateway address (`14: DNS Resolution failed`), or by the gateway not being ready yet (`14: UNAVAILABLE: failed to connect to all addresses`).
+-   Operations retry, but only for [gRPC error code 14](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) - indicating a transient network failure. This can be caused by passing in an unresolvable gateway address (`14: DNS Resolution failed`), or by the gateway not being ready yet (`14: UNAVAILABLE: failed to connect to all addresses`).
 -   Operations that fail for other reasons, such as deploying an invalid bpmn file or cancelling a workflow that does not exist, do not retry.
 -   Retry is enabled by default, and can be disabled by passing { retry: false } to the client constructor.
 -   `maxRetries` and `maxRetryTimeout` are also configurable through the constructor options. By default, if not supplied, the values are:

--- a/package-lock.json
+++ b/package-lock.json
@@ -646,6 +646,19 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
 			"integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
 		},
+		"@types/promise-retry": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+			"integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+			"requires": {
+				"@types/retry": "*"
+			}
+		},
+		"@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+		},
 		"@types/shelljs": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
@@ -2233,6 +2246,11 @@
 				"once": "^1.4.0"
 			}
 		},
+		"err-code": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3344,22 +3362,22 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"requires": {
 						"delegates": "^1.0.0",
@@ -3368,12 +3386,12 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -3382,47 +3400,47 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"requires": {
 						"minipass": "^2.2.1"
@@ -3430,12 +3448,12 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"requires": {
 						"aproba": "^1.0.3",
@@ -3450,12 +3468,12 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"resolved": false,
 					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -3463,7 +3481,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -3471,7 +3489,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
 						"once": "^1.3.0",
@@ -3480,17 +3498,17 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -3498,12 +3516,12 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -3511,12 +3529,12 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"minipass": {
 					"version": "2.3.5",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"requires": {
 						"safe-buffer": "^5.1.2",
@@ -3533,7 +3551,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"requires": {
 						"minimist": "0.0.8"
@@ -3541,7 +3559,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"resolved": false,
 							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 						}
 					}
@@ -3590,7 +3608,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"requires": {
 						"abbrev": "1",
@@ -3613,7 +3631,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -3624,17 +3642,17 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
 						"wrappy": "1"
@@ -3642,17 +3660,17 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -3661,12 +3679,12 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 				},
 				"protobufjs": {
@@ -3682,7 +3700,7 @@
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+					"resolved": false,
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"requires": {
 						"deep-extend": "^0.6.0",
@@ -3693,7 +3711,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -3730,17 +3748,17 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 				},
 				"semver": {
@@ -3750,17 +3768,17 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -3770,7 +3788,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -3778,7 +3796,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -3786,12 +3804,12 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"tar": {
 					"version": "4.4.8",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+					"resolved": false,
 					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"requires": {
 						"chownr": "^1.1.1",
@@ -3805,12 +3823,12 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"requires": {
 						"string-width": "^1.0.2 || 2"
@@ -3818,12 +3836,12 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
@@ -6941,6 +6959,15 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"promise-retry": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+			"requires": {
+				"err-code": "^1.0.0",
+				"retry": "^0.10.0"
+			}
+		},
 		"prompts": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
@@ -7858,6 +7885,11 @@
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
+		},
+		"retry": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 		},
 		"rimraf": {
 			"version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "A Node.js client library for the Zeebe Microservices Orchestration Engine.",
 	"keywords": [
 		"zeebe",
@@ -10,7 +10,8 @@
 		"bpmn",
 		"conductor",
 		"camunda",
-		"Netflix"
+		"Netflix",
+		"workflow"
 	],
 	"homepage": "https://creditsenseau.github.io/zeebe-client-node-js/",
 	"bugs": {
@@ -54,11 +55,13 @@
 		]
 	},
 	"dependencies": {
+		"@types/promise-retry": "^1.1.3",
 		"chalk": "^2.4.2",
 		"console-stamp": "^0.2.7",
 		"debug": "^4.1.1",
 		"fast-xml-parser": "^3.12.12",
 		"node-grpc-client": "^1.3.0",
+		"promise-retry": "^1.1.1",
 		"uuid": "^3.3.2"
 	},
 	"devDependencies": {
@@ -86,5 +89,13 @@
 		"name": "Josh Wulf",
 		"email": "josh@magikcraft.io"
 	},
+	"contributors": [
+		{
+			"name": "Timothy Colbert"
+		},
+		{
+			"name": "Jarred Filmer"
+		}
+	],
 	"license": "Apache-2.0"
 }

--- a/src/__tests__/ZBClient-unnmocked.spec.ts
+++ b/src/__tests__/ZBClient-unnmocked.spec.ts
@@ -1,0 +1,31 @@
+import { ZBClient } from '..'
+jest.unmock('node-grpc-client')
+
+describe('ZBClient constructor', () => {
+	it('throws an exception when there is no broker and retry is false', async () => {
+		const zbc = new ZBClient('localhoster', { retry: false })
+		expect.assertions(1)
+		try {
+			await zbc.deployWorkflow('./test/hello-world.bpmn')
+		} catch (e) {
+			expect(e.message.indexOf('14 UNAVAILABLE:')).toEqual(0)
+		}
+	})
+	it('does not throw when there is no broker, by default', async done => {
+		const zbc = new ZBClient('localhoster')
+		setTimeout(() => {
+			// tslint:disable-next-line
+			console.log(
+				'^^^ The gRPC connection failure message above is expected. ^^^'
+			)
+			zbc.close()
+			expect(true).toBe(true)
+			done()
+		}, 4000)
+		// tslint:disable-next-line
+		console.log(
+			'vvv The gRPC connection failure message below is expected. vvv'
+		)
+		await zbc.deployWorkflow('./test/hello-world.bpmn')
+	})
+})

--- a/src/__tests__/integration/ZBClient-integration.spec.ts
+++ b/src/__tests__/integration/ZBClient-integration.spec.ts
@@ -27,6 +27,7 @@ describe('ZBClient.deployWorkflow()', () => {
 	})
 
 	// Note: this will change in Zeebe 0.19!
+	// See: https://github.com/zeebe-io/zeebe/issues/1159
 	it('By default, it deploys a single workflow when that workflow is already deployed', async () => {
 		const res = await zbc.deployWorkflow('./test/hello-world.bpmn')
 		expect(res.workflows.length).toBe(1)

--- a/src/__tests__/integration/ZBClient-integration.spec.ts
+++ b/src/__tests__/integration/ZBClient-integration.spec.ts
@@ -26,22 +26,11 @@ describe('ZBClient.deployWorkflow()', () => {
 		expect(res.workflows[0].bpmnProcessId).toBe('hello-world')
 	})
 
+	// Note: this will change in Zeebe 0.19!
 	it('By default, it deploys a single workflow when that workflow is already deployed', async () => {
 		const res = await zbc.deployWorkflow('./test/hello-world.bpmn')
 		expect(res.workflows.length).toBe(1)
 		expect(res.workflows[0].version > 1).toBe(true)
-	})
-
-	it('With {redeploy: false} it will not redeploy an existing workflow', async () => {
-		const res = await zbc.deployWorkflow('./test/hello-world.bpmn', {
-			redeploy: false,
-		})
-		expect(res.key).toBe(-1)
-	})
-
-	it('Lists workflows', async () => {
-		const res = await zbc.listWorkflows()
-		expect(res.workflows).toBeTruthy()
 	})
 
 	it('Can create a worker', async () => {
@@ -300,5 +289,25 @@ describe('ZBClient.deployWorkflow()', () => {
 			// Manually verify that an incident has been raised
 			done()
 		})
+	})
+
+	it('does not retry the deployment of a broken BPMN file', async () => {
+		expect.assertions(1)
+		try {
+			await zbc.deployWorkflow('./test/broken-bpmn.bpmn')
+		} catch (e) {
+			expect(e.message.indexOf('3 INVALID_ARGUMENT:')).toBe(0)
+		}
+	})
+
+	it("does not retry to cancel a workflow instance that doesn't exist", async () => {
+		expect.assertions(1)
+		// See: https://github.com/zeebe-io/zeebe/issues/2680
+		// await zbc.cancelWorkflowInstance('123LoL')
+		try {
+			await zbc.cancelWorkflowInstance('2251799813686202')
+		} catch (e) {
+			expect(e.message.indexOf('5 NOT_FOUND:')).toBe(0)
+		}
 	})
 })

--- a/src/__tests__/integration/ZBClient-integration.spec.ts
+++ b/src/__tests__/integration/ZBClient-integration.spec.ts
@@ -306,7 +306,7 @@ describe('ZBClient.deployWorkflow()', () => {
 		// See: https://github.com/zeebe-io/zeebe/issues/2680
 		// await zbc.cancelWorkflowInstance('123LoL')
 		try {
-			await zbc.cancelWorkflowInstance('2251799813686202')
+			await zbc.cancelWorkflowInstance(2251799813686202)
 		} catch (e) {
 			expect(e.message.indexOf('5 NOT_FOUND:')).toBe(0)
 		}

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -262,4 +262,7 @@ export interface GetWorkflowResponse {
 export interface ZBClientOptions {
 	loglevel?: Loglevel
 	stdout?: any
+	retry?: boolean
+	maxRetries?: number
+	maxRetryTimeout?: number
 }

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -51,7 +51,7 @@ export interface ActivateJobsRequest {
 }
 
 export interface ActivatedJob {
-	key: string
+	key: number
 	type: string
 	jobHeaders: JobHeaders
 	/**
@@ -71,7 +71,7 @@ export interface ActivatedJob {
 }
 
 export interface Job<Variables = KeyedObject, CustomHeaders = KeyedObject> {
-	key: string
+	key: number
 	type: string
 	jobHeaders: JobHeaders
 	customHeaders: CustomHeaders
@@ -83,7 +83,7 @@ export interface Job<Variables = KeyedObject, CustomHeaders = KeyedObject> {
 }
 
 export interface JobHeaders {
-	workflowInstanceKey: string
+	workflowInstanceKey: number
 	bpmnProcessId: string
 	workflowDefinitionVersion: number
 	workflowKey: string
@@ -125,10 +125,10 @@ export interface CreateWorkflowInstanceRequest<Variables = KeyedObject> {
 }
 
 export interface CreateWorkflowInstanceResponse {
-	workflowKey: string
+	workflowKey: number
 	bpmnProcessId: string
 	version: number
-	workflowInstanceKey: string
+	workflowInstanceKey: number
 }
 
 export enum PartitionBrokerRole {
@@ -210,18 +210,18 @@ export interface PublishStartMessageRequest<Variables = KeyedObject> {
 }
 
 export interface UpdateJobRetriesRequest {
-	jobKey: string
+	jobKey: number
 	retries: number
 }
 
 export interface FailJobRequest {
-	jobKey: string
+	jobKey: number
 	retries: number
 	errorMessage: string
 }
 
 export interface CompleteJobRequest<Variables = KeyedObject> {
-	jobKey: string
+	jobKey: number
 	variables: Variables
 }
 
@@ -231,7 +231,7 @@ export interface SetVariablesRequest<Variables = KeyedObject> {
 	obtained during instance creation), or a given element, such as a service task (see
 	elementInstanceKey on the JobHeaders message)
 	*/
-	elementInstanceKey: string
+	elementInstanceKey: number
 	variables: Partial<Variables>
 	local: boolean
 }
@@ -242,7 +242,7 @@ export type GetWorkflowRequest =
 	| GetWorkflowRequestWithWorkflowKey
 
 export interface GetWorkflowRequestWithWorkflowKey {
-	workflowKey: string
+	workflowKey: number
 }
 
 export interface GetWorkflowRequestWithBpmnProcessId {
@@ -252,7 +252,7 @@ export interface GetWorkflowRequestWithBpmnProcessId {
 }
 
 export interface GetWorkflowResponse {
-	workflowKey: string
+	workflowKey: number
 	version: number
 	bpmnProcessId: string
 	resourceName: string

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -256,7 +256,7 @@ export class ZBClient {
 	}
 
 	public async cancelWorkflowInstance(
-		workflowInstanceKey: string
+		workflowInstanceKey: number
 	): Promise<void> {
 		return this.executeOperation(() =>
 			this.gRPCClient.cancelWorkflowInstanceSync({

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk'
 import * as fs from 'fs'
-import * as GRPCClient from 'node-grpc-client'
+import GRPCClient from 'node-grpc-client'
 import * as path from 'path'
+import promiseRetry from 'promise-retry'
 import { v4 as uuid } from 'uuid'
 import { BpmnParser, stringifyVariables } from '../lib'
 import * as ZB from '../lib/interfaces'
@@ -25,6 +26,9 @@ export class ZBClient {
 	private options: ZB.ZBClientOptions
 	private workerCount = 0
 	private workers: Array<ZBWorker<any, any, any>> = []
+	private retry: boolean
+	private maxRetries: number = 50
+	private maxRetryTimeout: number = 5000
 
 	constructor(gatewayAddress: string, options: ZB.ZBClientOptions = {}) {
 		if (!gatewayAddress) {
@@ -50,6 +54,10 @@ export class ZBClient {
 			'Gateway',
 			gatewayAddress
 		)
+
+		this.retry = options.retry !== false
+		this.maxRetries = options.maxRetries || this.maxRetries
+		this.maxRetryTimeout = options.maxRetryTimeout || this.maxRetryTimeout
 	}
 
 	/**
@@ -115,7 +123,7 @@ export class ZBClient {
 	 * Return the broker cluster topology
 	 */
 	public topology(): Promise<ZB.TopologyResponse> {
-		return this.gRPCClient.topologySync()
+		return this.executeOperation(this.gRPCClient.topologySync)
 	}
 
 	/**
@@ -125,32 +133,24 @@ export class ZBClient {
 	 * If set false, will not redeploy a workflow that exists.
 	 */
 	public async deployWorkflow(
-		workflow: string | string[],
-		{ redeploy = true } = {}
+		workflow: string | string[]
 	): Promise<ZB.DeployWorkflowResponse> {
 		const workflows = Array.isArray(workflow) ? workflow : [workflow]
-		let deployedWorkflows: any[] = []
-		if (!redeploy) {
-			deployedWorkflows = (await this.listWorkflows()).workflows.map(
-				(wf: any) => wf.bpmnProcessId
-			)
-		}
-		const workFlowRequests: ZB.WorkflowRequestObject[] = workflows
-			.map(wf => ({
+
+		const workFlowRequests: ZB.WorkflowRequestObject[] = workflows.map(
+			wf => ({
 				definition: fs.readFileSync(wf),
 				name: path.basename(wf),
 				type: 1,
-			}))
-			.filter(
-				wfr =>
-					!deployedWorkflows.includes(
-						BpmnParser.getProcessId(wfr.definition.toString())
-					)
-			)
-		if (workFlowRequests.length > 0) {
-			return this.gRPCClient.deployWorkflowSync({
-				workflows: workFlowRequests,
 			})
+		)
+
+		if (workFlowRequests.length > 0) {
+			return this.executeOperation(() =>
+				this.gRPCClient.deployWorkflowSync({
+					workflows: workFlowRequests,
+				})
+			)
 		} else {
 			return {
 				key: -1,
@@ -177,8 +177,10 @@ export class ZBClient {
 	public publishMessage<T = KeyedObject>(
 		publishMessageRequest: ZB.PublishMessageRequest<T>
 	): Promise<void> {
-		return this.gRPCClient.publishMessageSync(
-			stringifyVariables(publishMessageRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.publishMessageSync(
+				stringifyVariables(publishMessageRequest)
+			)
 		)
 	}
 
@@ -204,19 +206,25 @@ export class ZBClient {
 			correlationKey: uuid(),
 			...publishStartMessageRequest,
 		}
-		return this.gRPCClient.publishMessageSync(
-			stringifyVariables(publishMessageRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.publishMessageSync(
+				stringifyVariables(publishMessageRequest)
+			)
 		)
 	}
 
 	public updateJobRetries(
 		updateJobRetriesRequest: ZB.UpdateJobRetriesRequest
 	): Promise<void> {
-		return this.gRPCClient.updateJobRetriesSync(updateJobRetriesRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.updateJobRetriesSync(updateJobRetriesRequest)
+		)
 	}
 
 	public failJob(failJobRequest: ZB.FailJobRequest): Promise<void> {
-		return this.gRPCClient.failJobSync(failJobRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.failJobSync(failJobRequest)
+		)
 	}
 
 	/**
@@ -240,17 +248,21 @@ export class ZBClient {
 			variables: (variables as unknown) as object,
 			version,
 		}
-		return this.gRPCClient.createWorkflowInstanceSync(
-			stringifyVariables(createWorkflowInstanceRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.createWorkflowInstanceSync(
+				stringifyVariables(createWorkflowInstanceRequest)
+			)
 		)
 	}
 
 	public async cancelWorkflowInstance(
 		workflowInstanceKey: string
 	): Promise<void> {
-		return this.gRPCClient.cancelWorkflowInstanceSync({
-			workflowInstanceKey,
-		})
+		return this.executeOperation(() =>
+			this.gRPCClient.cancelWorkflowInstanceSync({
+				workflowInstanceKey,
+			})
+		)
 	}
 
 	public setVariables<Variables = KeyedObject>(
@@ -263,34 +275,57 @@ export class ZBClient {
 		if (typeof request.variables === 'object') {
 			request.variables = JSON.stringify(request.variables) as any
 		}
-		return this.gRPCClient.setVariablesSync(request)
-	}
-
-	public listWorkflows(
-		bpmnProcessId?: string
-	): Promise<ZB.ListWorkflowResponse> {
-		return this.gRPCClient.listWorkflowsSync({ bpmnProcessId })
-	}
-
-	public getWorkflow(
-		getWorkflowRequest: ZB.GetWorkflowRequest
-	): Promise<ZB.GetWorkflowResponse> {
-		if (this.hasBpmnProcessId(getWorkflowRequest)) {
-			getWorkflowRequest.version = getWorkflowRequest.version || -1
-		}
-		return this.gRPCClient.getWorkflowSync(getWorkflowRequest)
+		return this.executeOperation(() =>
+			this.gRPCClient.setVariablesSync(request)
+		)
 	}
 
 	public resolveIncident(incidentKey: string): Promise<void> {
-		return this.gRPCClient.resolveIncidentSync(incidentKey)
+		return this.executeOperation(() =>
+			this.gRPCClient.resolveIncidentSync(incidentKey)
+		)
 	}
 
-	private hasBpmnProcessId(
-		request: ZB.GetWorkflowRequest
-	): request is ZB.GetWorkflowRequestWithBpmnProcessId {
-		return (
-			(request as ZB.GetWorkflowRequestWithBpmnProcessId)
-				.bpmnProcessId !== undefined
+	/**
+	 * If this.retry is set true, the operation will be wrapped in an infinite retry on exception.
+	 * Otherwise it will be executed with no retry, and the application should handle the exception.
+	 * @param operation A gRPC command operation
+	 */
+	private async executeOperation<T>(operation: () => Promise<T>): Promise<T> {
+		return this.retry ? this.retryOnFailure(operation) : operation()
+	}
+
+	/**
+	 * This function takes a gRPC operation that returns a Promise as a function, and invokes it.
+	 * If the operation throws, this function will continue to try it until it succeeds.
+	 * @param operation A gRPC command operation that may fail if the broker is not available
+	 */
+	private async retryOnFailure<T>(operation: () => Promise<T>): Promise<T> {
+		const c = console
+		return promiseRetry(
+			(retry, n) => {
+				if (this.closing) {
+					return Promise.resolve() as any
+				}
+				if (n > 1) {
+					c.error(
+						`gRPC connection is in failed state. Attempt ${n}. Retrying in 5s...`
+					)
+				}
+				return operation().catch(err => {
+					// This could be DNS resolution, or the gRPC gateway is not reachable yet
+					const isNetworkError = err.message.indexOf('14') === 0
+					if (isNetworkError) {
+						c.error(`${err.message}`)
+						retry(err)
+					}
+					throw err
+				})
+			},
+			{
+				maxTimeout: this.maxRetryTimeout,
+				retries: this.maxRetries,
+			}
 		)
 	}
 }

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -287,8 +287,10 @@ export class ZBClient {
 	}
 
 	/**
-	 * If this.retry is set true, the operation will be wrapped in an infinite retry on exception.
-	 * Otherwise it will be executed with no retry, and the application should handle the exception.
+	 * If this.retry is set true, the operation will be wrapped in an configurable retry on exceptions
+	 * of gRPC error code 14 - Transient Network Failure.
+	 * See: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+	 * If this.retry is false, it will be executed with no retry, and the application should handle the exception.
 	 * @param operation A gRPC command operation
 	 */
 	private async executeOperation<T>(operation: () => Promise<T>): Promise<T> {
@@ -297,7 +299,8 @@ export class ZBClient {
 
 	/**
 	 * This function takes a gRPC operation that returns a Promise as a function, and invokes it.
-	 * If the operation throws, this function will continue to try it until it succeeds.
+	 * If the operation throws gRPC error 14, this function will continue to try it until it succeeds
+	 * or retries are exhausted.
 	 * @param operation A gRPC command operation that may fail if the broker is not available
 	 */
 	private async retryOnFailure<T>(operation: () => Promise<T>): Promise<T> {

--- a/test/broken-bpmn.bpmn
+++ b/test/broken-bpmn.bpmn
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1vwghmj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
-  <bpmn:process id="hello-world" name="Hello World" isExecutable="true">
+  <bpmn:process id="broken-bpmn" name="Hello World" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start&#10;&#10;">
       <bpmn:outgoing>SequenceFlow_0fp53hs</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:serviceTask id="ServiceTask_0g6tf5f" name="Say Hello World">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="console-log" retries="100" />
+        <zeebe:taskDefinition type="" retries="100" />
         <zeebe:taskHeaders>
           <zeebe:header key="message" value="Hello World" />
         </zeebe:taskHeaders>
@@ -32,7 +32,7 @@
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="hello-world">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="broken-bpmn">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="173" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,41 +1,35 @@
 {
-    "compilerOptions": {
-        /* Basic Options */
-        "target": "es2018", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-        "types": [
-            "node",
-            "jest"
-        ],
-        "lib": [
-            "es2017"
-        ],
-        "declaration": true, /* Generates corresponding '.d.ts' file. */
-        "sourceMap": true, /* Generates corresponding '.map' file. */
-        "outDir": "./dist", /* Redirect output structure to the directory. */
-        "rootDir": "./src", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-        /* Strict Type-Checking Options */
-        "forceConsistentCasingInFileNames": true,
-        "strict": true, /* Enable all strict type-checking options. */
-        "noImplicitAny": false, /* Raise error on expressions and declarations with an implied 'any' type. */
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "strictNullChecks": true,
-        "plugins": [
-            {
-                "name": "typescript-tslint-plugin"
-            }
-        ]
-    },
-    "include": [
-        "src/**/*.ts"
-    ],
-    "exclude": [
-        "src/**/*.spec.ts",
-        "src/__mocks__",
-        "dist",
-        "node_modules",
-        "docs"
-    ]
+	"compilerOptions": {
+		/* Basic Options */
+		"target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+		"types": ["node", "jest"],
+		"lib": ["es2017"],
+		"declaration": true /* Generates corresponding '.d.ts' file. */,
+		"sourceMap": true /* Generates corresponding '.map' file. */,
+		"outDir": "./dist" /* Redirect output structure to the directory. */,
+		"rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+		/* Strict Type-Checking Options */
+		"forceConsistentCasingInFileNames": true,
+		"strict": true /* Enable all strict type-checking options. */,
+		"noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"strictNullChecks": true,
+		"esModuleInterop": true,
+		"plugins": [
+			{
+				"name": "typescript-tslint-plugin"
+			}
+		]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": [
+		"src/**/*.spec.ts",
+		"src/__mocks__",
+		"dist",
+		"node_modules",
+		"docs"
+	]
 }


### PR DESCRIPTION
Fixes #40 

Notes below are from CHANGELOG.md and README.md:

### Remove methods that are removed in Zeebe 0.18

• Update for Zeebe 0.18.
• Remove `ZBClient.listWorkflows` and `ZBClient.getWorkflow` - the broker no longer provides a query API.
• Remove `{redeploy: boolean}` option from `ZBClient.deployWorkflow` method. This relies on `listWorkflows`. This will be the default behaviour in a future release of Zeebe. See [zeebe/#1159](https://github.com/zeebe-io/zeebe/issues/1159).
• Add client-side retry logic. Retries ZBClient gRPC command methods on failure due to [gRPC error code 14](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) (Transient Network Error). See [#40](https://github.com/creditsenseau/zeebe-client-node-js/issues/40).

### Client-side gRPC retry in ZBClient

If a gRPC command method fails in the ZBClient - such as `ZBClient.deployWorkflow` or `ZBClient.topology()`, the underlying gRPC library will throw an exception.

If no workers have been started, this can be fatal to the process if it is not handled by the application logic. This is especially an issue when a worker container starts before the Zeebe gRPC gateway is available to service requests, and can be inconsistent as this is a race condition.

To mitigate against this, the Node client implements some client-side gRPC operation retry logic by default. This can be configured, including disabled, via configuration in the client constructor.

-   Operations retry, but only for [gRPC error code 14](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) - indicating a transient network failure. This can be caused by passing in an unresolvable gateway address (`14: DNS Resolution failed`), or by the gateway not being ready yet (`14: UNAVAILABLE: failed to connect to all addresses`).
-   Operations that fail for other reasons, such as deploying an invalid bpmn file or cancelling a workflow that does not exist, do not retry.
-   Retry is enabled by default, and can be disabled by passing `{retry: false}` to the client constructor.
-   `maxRetries` and `maxRetryTimeout` are also configurable through the constructor options. By default, if not supplied, the values are:

```TypeScript
const zbc = new ZB.ZBClient(gatewayAddress, {
    retry: true,
    maxRetries: 50,
    maxRetryTimeout: 5000
})
```

Retry is provided by [promise-retry](https://www.npmjs.com/package/promise-retry), and the back-off strategy is simple ^2.