### PR TITLE
0.20.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,22 +93,34 @@ Retry is provided by [promise-retry](https://www.npmjs.com/package/promise-retry
 
 Additionally, the gRPC Client will contiually reconnect when in a failed state.
 
+### TLS
+
+Enable a secure connection by setting `useTLS: true`:
+
+```typescript
+const zbc = new ZB.ZBClient(tlsProxiedGatewayAddress, {
+	useTLS: true,
+})
+```
+
 ### OAuth
 
-In case you need to connect to a secured endpoint with OAuth (such as Camunda Cloud), you can pass in OAuth credentials. This will enable TLS, and handle the OAuth flow to get / renew a JWT:
+In case you need to connect to a secured endpoint with OAuth (such as Camunda Cloud), you can pass in OAuth credentials. This will enable TLS (unless you explicitly disable it with `useTLS: false`), and handle the OAuth flow to get / renew a JWT:
 
 ```typescript
 const zbc = new ZB.ZBClient("103ca930-6da6-4df7-aa97-941eb1f85040.zeebe.camunda.io:443", {
-	auth: {
+	oAuth: {
 		url: "https://login.cloud.camunda.io/oauth/token",
 		audience: "103ca930-6da6-4df7-aa97-941eb1f85040.zeebe.camunda.io",
 		clientId: "yStuGvJ6a1RQhy8DQpeXJ80yEpar3pXh",
 		clientSecret:
 		"WZahIGHjyj0-oQ7DZ_aH2wwNuZt5O8Sq0ZJTz0OaxfO7D6jaDBZxM_Q-BHRsiGO_",
-		cache: true
+		cacheOnDisk: true
 	}
 }
 ```
+
+The `cacheOnDisk` option will cache the token on disk, which can be useful in development if you are restarting the service frequently.
 
 ### Create a Task Worker
 

--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/lib/interfaces'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "v0.21.0",
+	"version": "v0.20.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "v0.20.2",
+	"version": "v0.20.3",
 	"description": "A Node.js client library for the Zeebe Microservices Orchestration Engine.",
 	"keywords": [
 		"zeebe",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { BpmnParser } from './lib/BpmnParser'
+export * from './lib/interfaces'
 export * from './zb/ZBClient'
 export * from './zb/ZBWorker'

--- a/src/lib/GRPCClient.ts
+++ b/src/lib/GRPCClient.ts
@@ -63,6 +63,7 @@ export class GRPCClient extends EventEmitter {
 		packageName,
 		protoPath,
 		service,
+		useTLS,
 	}: {
 		host: string
 		loglevel: Loglevel
@@ -71,6 +72,7 @@ export class GRPCClient extends EventEmitter {
 		packageName: string
 		protoPath: string
 		service: string
+		useTLS: boolean
 	}) {
 		super()
 		this.oAuth = oAuth
@@ -95,7 +97,7 @@ export class GRPCClient extends EventEmitter {
 
 		const proto = loadPackageDefinition(this.packageDefinition)[packageName]
 		const listMethods = this.packageDefinition[`${packageName}.${service}`]
-		const channelCredentials = oAuth
+		const channelCredentials = useTLS
 			? credentials.createSsl()
 			: credentials.createInsecure()
 		this.client = new proto[service](host, channelCredentials, {

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -11,7 +11,7 @@ export type Loglevel = 'INFO' | 'DEBUG' | 'NONE' | 'ERROR'
 export interface CompleteFn<WorkerOutputVariables> {
 	(updatedVariables?: Partial<WorkerOutputVariables>): boolean
 	/**
-	 * Complete the job with a success, optionallu passing in a state update to merge
+	 * Complete the job with a success, optionally passing in a state update to merge
 	 * with the workflow variables on the broker.
 	 */
 	success: (updatedVariables?: Partial<WorkerOutputVariables>) => boolean

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -319,7 +319,8 @@ export interface ZBClientOptions {
 	retry?: boolean
 	maxRetries?: number
 	maxRetryTimeout?: number
-	auth?: OAuthProviderConfig
+	oAuth?: OAuthProviderConfig
+	useTLS?: boolean
 	longPoll?: number
 }
 

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -10,6 +10,7 @@ import * as ZB from '../lib/interfaces'
 import { OAuthProvider } from '../lib/OAuthProvider'
 // tslint:disable-next-line: no-duplicate-imports
 import { Utils } from '../lib/utils'
+import { ZBLogger } from '../lib/ZBLogger'
 import { ZBWorker } from './ZBWorker'
 
 const DEFAULT_GATEWAY_PORT = '26500'
@@ -34,6 +35,7 @@ export class ZBClient {
 	private maxRetries: number = 50
 	private maxRetryTimeout: number = 5000
 	private loglevel: ZB.Loglevel
+	private logger: ZBLogger
 	private oAuth?: OAuthProvider
 	private useTLS: boolean
 
@@ -48,7 +50,10 @@ export class ZBClient {
 			(process.env.ZB_NODE_LOG_LEVEL as ZB.Loglevel) ||
 			options.loglevel ||
 			'INFO'
-
+		this.logger = new ZBLogger({
+			loglevel: this.loglevel,
+			taskType: 'ZBClient',
+		})
 		const includesProtocol = gatewayAddress.includes('://')
 		if (!includesProtocol) {
 			gatewayAddress = `grpc://${gatewayAddress}`
@@ -62,7 +67,8 @@ export class ZBClient {
 		this.oAuth = options.oAuth
 			? new OAuthProvider(options.oAuth)
 			: undefined
-		this.useTLS = options.useTLS !== false && !options.oAuth
+		this.useTLS = options.useTLS === true || !!options.oAuth
+		this.logger.info(`Use TLS: ${this.useTLS}`)
 
 		this.gRPCClient = new GRPCClient({
 			host: this.gatewayAddress,

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -35,6 +35,7 @@ export class ZBClient {
 	private maxRetryTimeout: number = 5000
 	private loglevel: ZB.Loglevel
 	private oAuth?: OAuthProvider
+	private useTLS: boolean
 
 	constructor(gatewayAddress: string, options: ZB.ZBClientOptions = {}) {
 		if (!gatewayAddress) {
@@ -58,7 +59,10 @@ export class ZBClient {
 
 		this.gatewayAddress = `${url.hostname}:${url.port}`
 
-		this.oAuth = options.auth ? new OAuthProvider(options.auth) : undefined
+		this.oAuth = options.oAuth
+			? new OAuthProvider(options.oAuth)
+			: undefined
+		this.useTLS = options.useTLS !== false && !options.oAuth
 
 		this.gRPCClient = new GRPCClient({
 			host: this.gatewayAddress,
@@ -68,6 +72,7 @@ export class ZBClient {
 			packageName: 'gateway_protocol',
 			protoPath: path.join(__dirname, '../../proto/zeebe.proto'),
 			service: 'Gateway',
+			useTLS: this.useTLS,
 		}) as ZB.ZBGRPC
 
 		this.retry = options.retry !== false
@@ -112,6 +117,7 @@ export class ZBClient {
 			packageName: 'gateway_protocol',
 			protoPath: path.join(__dirname, '../../proto/zeebe.proto'),
 			service: 'Gateway',
+			useTLS: this.useTLS,
 		}) as ZB.ZBGRPC
 		const worker = new ZBWorker<
 			WorkerInputVariables,

--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -296,7 +296,7 @@ export class ZBClient {
 			version,
 		}
 
-		return ZB.noRetry(options)
+		return options.retry === false
 			? this.executeOperation(() =>
 					this.gRPCClient.createWorkflowInstanceSync(
 						stringifyVariables(createWorkflowInstanceRequest)


### PR DESCRIPTION
This PR:

0. Allows users to turn on TLS without using OAuth (was a regression in 0.21.2).
1. Exports the Typescript definitions for interfaces. They are now consumable via `import * as Interfaces from 'zeebe-node/interfaces'`. This will enable workit, zeebe-nestjs, and any other libraries that extend zeebe-node to have cleaner imports.
2. Improves Intellisense documentation.

