### PR TITLE
Inject stdout. Fixes #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# Version v0.21
+# Version 0.20.6
+
+-   _BREAKING CHANGE_: Remove `complete()` in job handler callback. Use `complete.success()`.
+-   Inject stdout to logger in GRPC client. Fixes [#74](https://github.com/creditsenseau/zeebe-client-node-js/issues/74).
+
+# Version 0.20.5
+
+-   Add support for the Zeebe service on Camunda Cloud.
+
+# Version v0.20.1
 
 • Add long polling support. See [#64](https://github.com/creditsenseau/zeebe-client-node-js/issues/64).
 • @TODO: Add authentication via JWT.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ zbc.createWorker('test-worker', 'console-log', maybeFaultyHandler, {
 
 To complete a task, the task worker handler function receives a `complete` method. This method has a `success` and a `failure` method (as well as being able to be called directly). Calling the method directly - `complete()` is the same as calling `complete.success()`.
 
-Call `complete.success()` (or just `complete()`) passing in a optional plain old JavaScript object (POJO) - a key:value map. These are variable:value pairs that will be used to update the workflow state in the broker.
+Call `complete.success()` passing in a optional plain old JavaScript object (POJO) - a key:value map. These are variable:value pairs that will be used to update the workflow state in the broker. They will be merged with existing values. You can set an existing key to `null` or `undefined`, but there is no way to delete a key.
 
 Call `complete.failure()` to fail the task. You must pass in a string message describing the failure. The client library decrements the retry count, and the broker handles the retry logic. If the failure is a hard failure and should cause an incident to be raised in Operate, then pass in `0` for the optional second parameter, `retries`:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The following environment variable configurations are possible with the Zero-con
 Camunda Cloud:
 
 ```
-ZEEBE_CAMUNDA_CLOUD_CLUSTER_ID
+ZEEBE_GATEWAY_ADDRESS
 ZEEBE_CLIENT_SECRET
 ZEEBE_CLIENT_ID
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "v0.20.3",
+	"version": "v0.20.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zeebe-node",
-	"version": "v0.20.5",
+	"version": "v0.20.6",
 	"description": "A Node.js client library for the Zeebe Microservices Orchestration Engine.",
 	"keywords": [
 		"zeebe",

--- a/src/__tests__/StdOut.spec.ts
+++ b/src/__tests__/StdOut.spec.ts
@@ -13,6 +13,7 @@ describe('StdOut Substitution', () => {
 			z.close()
 		}, 2000)
 		setTimeout(() => {
+			expect(mockStd.messages.length > 0).toBe(true)
 			done()
 		}, 4000)
 	})

--- a/src/__tests__/StdOut.spec.ts
+++ b/src/__tests__/StdOut.spec.ts
@@ -1,0 +1,19 @@
+import { ZBClient } from '..'
+import { MockStdOut } from '../lib/MockStdOut'
+
+jest.setTimeout(15000)
+
+describe('StdOut Substitution', () => {
+	it('uses an injected stdout', done => {
+		const mockStd = new MockStdOut()
+		const z = new ZBClient({ stdout: mockStd })
+		// tslint:disable-next-line: no-console
+		z.createWorker(null, 'test', console.log)
+		setTimeout(() => {
+			z.close()
+		}, 2000)
+		setTimeout(() => {
+			done()
+		}, 4000)
+	})
+})

--- a/src/__tests__/ZBClient-unmocked.spec.ts
+++ b/src/__tests__/ZBClient-unmocked.spec.ts
@@ -1,5 +1,7 @@
 import { ZBClient } from '..'
 
+jest.setTimeout(12000)
+
 describe('ZBClient constructor', () => {
 	it('throws an exception when there is no broker and retry is false', async () => {
 		const zbc = new ZBClient('localhoster', { retry: false })
@@ -14,15 +16,16 @@ describe('ZBClient constructor', () => {
 	})
 	it('does not throw when there is no broker, by default', async done => {
 		const zbc = new ZBClient('localhoster')
-		setTimeout(() => {
+		setTimeout(async () => {
 			// tslint:disable-next-line
 			console.log(
 				'^^^ The gRPC connection failure message above is expected. ^^^'
 			)
-			zbc.close()
+			await zbc.close()
 			expect(true).toBe(true)
-			done()
-		}, 4000)
+			// We have to wait ten seconds here, because the operation retry logic keeps it alive (I think...)
+			setTimeout(() => done(), 10000)
+		}, 2000)
 		// tslint:disable-next-line
 		console.log(
 			'vvv The gRPC connection failure message below is expected. vvv'

--- a/src/__tests__/integration/Client-MessageStart.spec.ts
+++ b/src/__tests__/integration/Client-MessageStart.spec.ts
@@ -35,7 +35,7 @@ describe('ZBClient', () => {
 			'test2',
 			'console-log-msg',
 			async (job, complete) => {
-				complete(job.variables)
+				complete.success(job.variables)
 				expect(
 					job.customHeaders.message.indexOf('Workflow') !== -1
 				).toBe(true)

--- a/src/__tests__/integration/Worker-LongPoll.spec.ts
+++ b/src/__tests__/integration/Worker-LongPoll.spec.ts
@@ -26,9 +26,8 @@ describe('ZBWorker', () => {
 			'console-log-long-poll',
 			async (job, complete, worker) => {
 				expect(job.workflowInstanceKey).toBe(wf1.workflowInstanceKey)
-				complete(job.variables)
+				complete.success(job.variables)
 				expect(worker.pollCount > 5).toBe(true)
-				// await zbc.cancelWorkflowInstance(wf.workflowInstanceKey)
 				await zbc.close()
 				done()
 			},
@@ -54,14 +53,14 @@ describe('ZBWorker', () => {
 			'console-log-long-poll',
 			async (job, complete, worker) => {
 				expect(job.workflowInstanceKey).toBe(wf2.workflowInstanceKey)
-				complete(job.variables)
+				complete.success(job.variables)
 				expect(worker.pollCount).toBe(1)
-				// await zbcLongPoll.cancelWorkflowInstance(wf.workflowInstanceKey)
 				await zbcLongPoll.close()
 				done()
 			},
 			{ loglevel: 'NONE', debug: true }
 		)
+		// Wait to outside 10s - it should have only polled once when it gets the job
 		setTimeout(async () => {
 			wf2 = await zbcLongPoll.createWorkflowInstance('long-poll', {})
 		}, 13000)

--- a/src/__tests__/integration/ZBClient-integration.spec.ts
+++ b/src/__tests__/integration/ZBClient-integration.spec.ts
@@ -47,7 +47,7 @@ describe('ZBClient', () => {
 			'test',
 			'TASK_TYPE',
 			(job, complete) => {
-				complete(job)
+				complete.success(job)
 			},
 			{ loglevel: 'NONE' }
 		)
@@ -104,7 +104,7 @@ describe('ZBClient', () => {
 			'wait',
 			async (job, complete) => {
 				expect(job.workflowInstanceKey).toBe(wfi)
-				complete(job)
+				complete.success(job)
 			},
 			{ loglevel: 'NONE' }
 		)
@@ -115,7 +115,7 @@ describe('ZBClient', () => {
 			async (job, complete) => {
 				expect(job.workflowInstanceKey).toBe(wfi)
 				expect(job.variables.conditionVariable).toBe(true)
-				complete(job)
+				complete.success(job)
 				done()
 			},
 			{ loglevel: 'NONE' }
@@ -150,7 +150,7 @@ describe('ZBClient', () => {
 			'wait',
 			async (job, complete) => {
 				expect(job.workflowInstanceKey).toBe(wfi)
-				complete(job)
+				complete.success(job)
 			},
 			{ loglevel: 'NONE' }
 		)
@@ -161,7 +161,7 @@ describe('ZBClient', () => {
 			async (job, complete) => {
 				expect(job.workflowInstanceKey).toBe(wfi)
 				expect(job.variables.conditionVariable).toBe(false)
-				complete(job.variables)
+				complete.success(job.variables)
 				done()
 			},
 			{ loglevel: 'NONE' }

--- a/src/__tests__/integration/ZBWorker-integration.spec.ts
+++ b/src/__tests__/integration/ZBWorker-integration.spec.ts
@@ -31,7 +31,7 @@ describe('ZBWorker', () => {
 			'console-log',
 			async (job, complete) => {
 				expect(job.workflowInstanceKey).toBe(wf.workflowInstanceKey)
-				complete(job.variables)
+				complete.success(job.variables)
 				done()
 			},
 			{ loglevel: 'NONE' }

--- a/src/lib/GRPCClient.ts
+++ b/src/lib/GRPCClient.ts
@@ -47,6 +47,7 @@ const connectivityState = [
 ]
 
 export class GRPCClient extends EventEmitter {
+	public channelClosed = false
 	public longPoll?: number
 	public client: Client
 	private packageDefinition: PackageDefinition
@@ -54,7 +55,6 @@ export class GRPCClient extends EventEmitter {
 	private logger: ZBLogger
 	private gRPCRetryCount = 0
 	private oAuth?: OAuthProvider
-	private channelClosed = false
 
 	constructor({
 		host,
@@ -199,6 +199,9 @@ export class GRPCClient extends EventEmitter {
 	private watchGrpcChannel(): Promise<number> {
 		return new Promise(resolve => {
 			const gRPC = this.client
+			if (this.channelClosed) {
+				return
+			}
 			const state = gRPC.getChannel().getConnectivityState(false)
 			this.logger.error(`GRPC Channel State: ${connectivityState[state]}`)
 			const deadline = new Date().setSeconds(

--- a/src/lib/MockStdOut.ts
+++ b/src/lib/MockStdOut.ts
@@ -1,0 +1,13 @@
+export class MockStdOut {
+	public messages: string[] = []
+
+	public info(message: string) {
+		this.messages.push(message)
+	}
+
+	public error(message: string) {
+		// tslint:disable-next-line: no-console
+		console.log(arguments)
+		this.messages.push(message)
+	}
+}

--- a/src/lib/MockStdOut.ts
+++ b/src/lib/MockStdOut.ts
@@ -6,8 +6,6 @@ export class MockStdOut {
 	}
 
 	public error(message: string) {
-		// tslint:disable-next-line: no-console
-		console.log(arguments)
 		this.messages.push(message)
 	}
 }

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -9,12 +9,13 @@ export interface KeyedObject {
 export type Loglevel = 'INFO' | 'DEBUG' | 'NONE' | 'ERROR'
 
 export interface CompleteFn<WorkerOutputVariables> {
-	(updatedVariables?: Partial<WorkerOutputVariables>): boolean
 	/**
 	 * Complete the job with a success, optionally passing in a state update to merge
 	 * with the workflow variables on the broker.
 	 */
-	success: (updatedVariables?: Partial<WorkerOutputVariables>) => boolean
+	success: (
+		updatedVariables?: Partial<WorkerOutputVariables>
+	) => Promise<boolean>
 	/**
 	 * Fail the job with an informative message as to the cause. Optionally pass in a
 	 * value remaining retries. If no value is passed for retries then the current retry

--- a/src/zb/ZBWorker.ts
+++ b/src/zb/ZBWorker.ts
@@ -95,6 +95,9 @@ export class ZBWorker<
 		this.cancelWorkflowOnException =
 			options.failWorkflowOnException || false
 		this.zbClient = zbClient
+		// tslint:disable-next-line: no-console
+		console.log(options.stdout) // @DEBUG
+
 		this.logger = new ZBLogger({
 			color: idColor,
 			id: this.id,
@@ -140,6 +143,7 @@ export class ZBWorker<
 
 			if (this.activeJobs <= 0) {
 				clearInterval(this.keepAlive)
+				this.gRPCClient.close()
 				resolve()
 			} else {
 				this.capacityEmitter.once('empty', () => {


### PR DESCRIPTION
* Remove `complete()` in job handler callback. Use `complete.success()`.
*  Inject stdout into logger in GRPC client. Fixes #74
