### PR TITLE
Allow to complete a job via ZBClient

### DIFF
--- a/src/zb/ZBClient.ts
+++ b/src/zb/ZBClient.ts
@@ -343,6 +343,14 @@ export class ZBClient {
 		)
 	}
 
+	public completeJob(
+		completeJobRequest: ZB.CompleteJobRequest
+	): Promise<void> {
+		const withStringifiedVariables = stringifyVariables(completeJobRequest)
+		this.logger.debug(withStringifiedVariables)
+		return this.gRPCClient.completeJobSync(withStringifiedVariables)
+	}
+
 	// tslint:disable: no-object-literal-type-assertion
 	public createWorkflowInstance<Variables = ZB.GenericWorkflowVariables>(
 		bpmnProcessId: string,

--- a/src/zb/ZBWorker.ts
+++ b/src/zb/ZBWorker.ts
@@ -1,7 +1,7 @@
 import { Chalk } from 'chalk'
 import { EventEmitter } from 'events'
 import * as uuid from 'uuid'
-import { parseVariables, stringifyVariables } from '../lib'
+import { parseVariables } from '../lib'
 import { GRPCClient } from '../lib/GRPCClient'
 import * as ZB from '../lib/interfaces'
 import { ZBLogger } from '../lib/ZBLogger'
@@ -148,14 +148,6 @@ export class ZBWorker<
 	public work = () => {
 		this.logger.log(`Ready for ${this.taskType}...`)
 		this.longPollLoop()
-	}
-
-	public completeJob(
-		completeJobRequest: ZB.CompleteJobRequest
-	): Promise<void> {
-		const withStringifiedVariables = stringifyVariables(completeJobRequest)
-		this.logger.debug(withStringifiedVariables)
-		return this.gRPCClient.completeJobSync(withStringifiedVariables)
 	}
 
 	public log(msg: any) {
@@ -335,7 +327,7 @@ export class ZBWorker<
 					}
 				},
 				success: async (completedVariables = {}) => {
-					await this.completeJob({
+					await this.zbClient.completeJob({
 						jobKey: job.key,
 						variables: completedVariables,
 					})


### PR DESCRIPTION
This allows to complete a job directly using the ZBClient.
Useful if you want to complete a job decoupled from the worker.

Our scenario is following, where the `zeebe-fulfiller` will just complete / fail jobs. 
![zeebe-lambdas](https://user-images.githubusercontent.com/4059042/69066683-ff33ba00-0a21-11ea-940a-313948e56770.jpg)
