### PR TITLE
Fixes error on instantiation of OAuthProvider if cacheDir doesn't exist.

### DIFF
--- a/src/lib/OAuthProvider.ts
+++ b/src/lib/OAuthProvider.ts
@@ -60,6 +60,8 @@ export class OAuthProvider {
 			try {
 				if (!fs.existsSync(OAuthProvider.cacheDir)) {
 					fs.mkdirSync(OAuthProvider.cacheDir)
+				} else {
+					fs.accessSync(OAuthProvider.cacheDir, fs.constants.W_OK)
 				}
 			} catch (e) {
 				throw new Error(

--- a/src/lib/OAuthProvider.ts
+++ b/src/lib/OAuthProvider.ts
@@ -58,10 +58,8 @@ export class OAuthProvider {
 
 		if (this.useFileCache) {
 			try {
-				if (!fs.existsSync(OAuthProvider.cacheDir)) {
-					fs.mkdirSync(OAuthProvider.cacheDir)
-				} else {
-					fs.accessSync(OAuthProvider.cacheDir, fs.constants.W_OK)
+				if (!this.createCacheDirIfNotExists()) {
+					this.checkCacheDirAccess();
 				}
 			} catch (e) {
 				throw new Error(
@@ -167,5 +165,17 @@ export class OAuthProvider {
 			return
 		}
 		setTimeout(() => delete this.tokenCache[this.clientId], validityPeriod)
+	}
+
+	private createCacheDirIfNotExists(): boolean {
+		if (!fs.existsSync(OAuthProvider.cacheDir)) {
+			fs.mkdirSync(OAuthProvider.cacheDir);
+			return true;
+		}
+		return false;
+	}
+
+	private checkCacheDirAccess(): void {
+		fs.accessSync(OAuthProvider.cacheDir, fs.constants.W_OK)
 	}
 }

--- a/src/lib/OAuthProvider.ts
+++ b/src/lib/OAuthProvider.ts
@@ -58,10 +58,12 @@ export class OAuthProvider {
 
 		if (this.useFileCache) {
 			try {
-				fs.accessSync(OAuthProvider.cacheDir, fs.constants.W_OK)
+				if (!fs.existsSync(OAuthProvider.cacheDir)) {
+					fs.mkdirSync(OAuthProvider.cacheDir)
+				}
 			} catch (e) {
 				throw new Error(
-					`FATAL: Cannot write to OAuth cache dir ${OAuthProvider.cacheDir}\n` +
+					`FATAL: Cannot create the OAuth cache dir ${OAuthProvider.cacheDir}\n` +
 						'If you are running on AWS Lambda, set the HOME environment variable of your lambda function to /tmp'
 				)
 			}
@@ -131,9 +133,6 @@ export class OAuthProvider {
 	private toFileCache(token: Token) {
 		const d = new Date()
 		const file = OAuthProvider.cachedTokenFile(this.clientId)
-		if (!fs.existsSync(OAuthProvider.cacheDir)) {
-			fs.mkdirSync(OAuthProvider.cacheDir)
-		}
 		fs.writeFile(
 			file,
 			JSON.stringify({


### PR DESCRIPTION
The changes in #110 (https://github.com/creditsenseau/zeebe-client-node-js/commit/275bf6f78aa4c423a828df059c20cb24c2cfaeef) introduced a bug that the instantiation of the `OAuthProvider` fails if the `OAuthProvidr.cacheDir` doesn't exist.

The line [fs.accessSync(OAuthProvider.cacheDir, fs.constants.W_OK)](https://github.com/creditsenseau/zeebe-client-node-js/blob/275bf6f78aa4c423a828df059c20cb24c2cfaeef/src/lib/OAuthProvider.ts#L61) checks if it has write access to the directory `${homedir}/.camunda`. Usually at first execution the directory `.camunda` doesn't exists and `fs.acceessSync` will throw something like `Error: ENOENT: no such file or directory, access`.

This PR just checks in the constructor if the `cacheDir` exists and if not creates it.