### PR TITLE
fix(ci): npm build not properly executed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ jobs:
           command: npm test
       - run:
           name: build
-          command: npm run build
+          command: |-
+            npm run build
+            ls dist 2&>/dev/null || echo "dist directory missing"
       - run:
           name: npmrc
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
 	"main": "dist/index.js",
 	"bin": "./bin/zeebe-node",
 	"scripts": {
-		"build": "tsc",
-		"watch": "tsc -w",
-		"prepare": "tsc",
+		"build": "tsc --build src/tsconfig.json",
+		"watch": "tsc --build src/tsconfig.json -w",
+		"prepare": "tsc --build src/tsconfig.json",
 		"test": "jest --runInBand --detectOpenHandles --testPathIgnorePatterns integration local-integration disconnection",
 		"test:integration": "jest --runInBand --testPathIgnorePatterns disconnection --detectOpenHandles --verbose true",
 		"test:local": "jest --runInBand --verbose true --detectOpenHandles local-integration",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+                "composite": true, /* Required because referenced by src/tsconfig.json */
 		/* Basic Options */
 		"target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
 		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,


### PR DESCRIPTION
fixes #163

* `tsc` needs to be executed with `--build src/tsconfig.json`, otherwise it doesn't pick up the proper files to compile.
* added a smoke test in the publish step to catch a nonexistent `dist` directory.